### PR TITLE
Fix 2 small nginx configuration error

### DIFF
--- a/config/nginx/sync-endpoint-http.conf
+++ b/config/nginx/sync-endpoint-http.conf
@@ -1,5 +1,5 @@
 server {
-	listen 443;
+	listen 80;
 
 	# use favicon from Sync Endpoint
 	location = /favicon.ico {

--- a/config/nginx/sync-endpoint-https.conf
+++ b/config/nginx/sync-endpoint-https.conf
@@ -1,6 +1,6 @@
 server {
 	listen 80;
-	return 301 https://$host:$server_port$request_uri;
+	return 301 https://$host$request_uri;
 }
 
 server {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - "443:443"
     configs:
       - source: com.nginx.sync-endpoint.conf
-        target: /etc/nginx/conf.d/sync-endpoint.conf
+        target: /etc/nginx/conf.d/default.conf
       - source: com.nginx.proxy_buffer.conf
         target: /etc/nginx/conf.d/proxy_buffer.conf
     # uncomment these after uncommenting the ones below in the root level


### PR DESCRIPTION
1. When accessing from localhost, nginx's default configuration is more specific so ours gets overridden. 
2. HTTP only hosting has wrong default port. 