### PR TITLE
Update security.properties for DHIS2 Authentication

### DIFF
--- a/config/sync-endpoint/security.properties
+++ b/config/sync-endpoint/security.properties
@@ -1,7 +1,7 @@
 security.server.secureChannelType=ANY_CHANNEL
 security.server.channelType=ANY_CHANNEL
 
-# currently supported options are activeDirectory and ldap
+# currently supported options are activeDirectory, ldap and dhis2
 security.server.authenticationMethod=ldap
 
 #
@@ -49,6 +49,22 @@ security.server.userDnPattern=${security.server.usernameAttribute}={0},${securit
 security.server.memberOfGroupSearchFilter=(memberUid={1})
 # {0} is groupPrefix, {1} is groupRoleAttribute, this filter is for searching all groups
 security.server.serverGroupSearchFilter=(&(objectClass=posixGroup)({1}={0} *))
+
+#
+# Settings for DHIS2 Authentication
+#
+security.server.dhis2ApiUrl=http://YOUR_DHIS2_SERVER/api/VERSION
+# a DHIS2 user with privilege to enumerate organizaion units, groups and users
+security.server.dhis2AdminUsername=YOUR_ADMIN_USERNAME
+security.server.dhis2AdminPassword=YOUR_ADMIN_PASSWORD
+# name of a DHIS2 orgnaization unit / group to assign Sync Endpoint Site Admins role to
+security.server.dhis2SiteAdmins=ODK_SITE_ADMIN
+security.server.dhis2AdministerTables=ODK_ADMIN_TABLES
+security.server.dhis2SuperUserTables=ODK_SUPER_USER_TABLES
+security.server.dhis2SyncTables=ODK_SYNC_TABLES
+security.server.dhis2FormManagers=ODK_FORM_MNGR
+security.server.dhis2DataViewers=ODK_DATA_VIEWERS
+security.server.dhis2DataCollectors=ODK_DATA_COLLECTORS
 
 wink.handlersFactoryClass=org.opendatakit.aggregate.odktables.impl.api.wink.AppEngineHandlersFactory
 


### PR DESCRIPTION
Update `security.properties` to add fields needed for DHIS2 Authentication. 