### PR TITLE
Set osixia/openldap version to 1.2.2

### DIFF
--- a/openldap/Dockerfile
+++ b/openldap/Dockerfile
@@ -1,4 +1,4 @@
-FROM osixia/openldap
+FROM osixia/openldap:1.2.2
 
 # should move this file to ldif/custom directory 
 # feature should be in the next release


### PR DESCRIPTION
There is a bug in osixia/openldap version 1.2.3 that prevents a container using the image from starting up. This commit locks the version of our openldap image to pull from version 1.2.2. 

We should update after the bug is fixed upstream. 