### PR TITLE
Fix db password

### DIFF
--- a/db.env
+++ b/db.env
@@ -1,5 +1,5 @@
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgresPostgresPassword
+POSTGRES_USER=odk
+POSTGRES_PASSWORD=odk
 POSTGRES_DB=postgres
 
 # DB Bootstrap


### PR DESCRIPTION
Sync expects database username and password to be 'odk'. 
Before this change, I could not log in to the sync endpoint server.