### PR TITLE
Fix certbot renewal in field systems

### DIFF
--- a/docker-compose-https.yml
+++ b/docker-compose-https.yml
@@ -48,14 +48,15 @@ services:
     entrypoint: /bin/sh -c "trap exit TERM; while :;\
       do \
       echo $$HTTPS_ADMIN_EMAIL; \
-      certbot renew --webroot -w /var/www/certbot \
+      certbot certonly --webroot -w /var/www/certbot \
       --email $$HTTPS_ADMIN_EMAIL \
       -d $$HTTPS_DOMAIN \
       --rsa-key-size 4096 \
       --agree-tos \
-      --cert-name production \
+      --cert-name renewal-staging \
       --keep-until-expiring \
-      --non-interactive; \
+      --non-interactive && \
+      cp /etc/letsencrypt/live/renewal-staging/*.pem /etc/letsencrypt/live/production; \
       sleep 11h & wait $${!};\
       done; \
       "


### PR DESCRIPTION
The test setup used for the initial integration of certbot renewal had
additional metadata present that allowed the renew command to complete
successfully. In production after a minimal bootstrap this metadata is
not available. This commit updates the renewal flow to generate a new
"staging" certificate, which is then copied over to the production
directory if it's updated successfully. This allows certbot to
generate the metadata required to update the certificate in the
future. The certonly command works for both the initial allocation of
a new certificate as well as the update of an existing certificate.

This commit was tested on a clean cloud host (azure), and validated
that an update occurs when needed while not executing extra queries
to the CA when the staging certificate is present and not due for
renewal.