### PR TITLE
Add a top-level gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore changes to the example https environment file
+config/https.env


### PR DESCRIPTION
Start by ignoring the https config file, which will be
customized by the init script with each deployment.