### PR TITLE
Change command to perform shalow checkout

### DIFF
--- a/init-odkx-sync-endpoint.py
+++ b/init-odkx-sync-endpoint.py
@@ -151,7 +151,7 @@ def run_docker_builds():
 
 
 def run_sync_endpoint_build():
-    os.system("git clone https://github.com/odk-x/sync-endpoint ; \
+    os.system("git clone -b master --single-branch --depth=1 https://github.com/odk-x/sync-endpoint ; \
                cd sync-endpoint ; \
                mvn -pl org.opendatakit:sync-endpoint-war,org.opendatakit:sync-endpoint-docker-swarm,org.opendatakit:sync-endpoint-common-dependencies clean install -DskipTests")
 


### PR DESCRIPTION
git clone command is modified to fetch only the latest commit.
should fix https://github.com/odk-x/tool-suite-X/issues/249